### PR TITLE
Merge changes on IMU Driver to Develop

### DIFF
--- a/CM4/Core/Inc/sensorDataType.h
+++ b/CM4/Core/Inc/sensorDataType.h
@@ -1,0 +1,16 @@
+#ifndef SENSORDATATYPE_H
+#define SENSORDATATYPE_H
+
+struct Acceleration { 
+    float ax; 
+    float ay; 
+    float az; 
+};
+
+struct Gyroscope { 
+    float gx; 
+    float gy; 
+    float gz; 
+};
+
+#endif /* SENSORDATATYPE_H */

--- a/Modules/IMU/lsm6dso.cpp
+++ b/Modules/IMU/lsm6dso.cpp
@@ -2,17 +2,36 @@
 /* Includes ------------------------------------------------------------------*/
 
 #include "lsm6dso.h"
-#include "stm32wlxx_hal.h"
 
-/* Private includes ----------------------------------------------------------*/
+/* Public methods ----------------------------------------------------------*/
 
-
-
-Lsm6dso::Lsm6dso(uint8_t i2cAddr, Lsm6dsoI3C i3c, Lsm6dsoOdrAcc odrAcc, Lsm6dsoFsAcc fsAcc, Lsm6dsoOdrGyr odrGyr, Lsm6dsoFsGyr fsGyr,
-		Lsm6dsoWakeThs wakeThs, Lsm6dsoWakeDur wakeDur, Lsm6dsoWakeWeight wakeWeight, Lsm6dsoSleepDur sleepDur){
-	this->i2cAddr = i2cAddr;
+Lsm6dso::Lsm6dso(I2C_HandleTypeDef *hi2c, uint8_t i2cAddr, Lsm6dsoI3C i3c, Lsm6dsoOdrAcc odrAcc, Lsm6dsoFsAcc fsAcc, Lsm6dsoOdrGyr odrGyr, Lsm6dsoFsGyr fsGyr, Lsm6dsoWakeThs wakeThs, Lsm6dsoWakeDur wakeDur, Lsm6dsoWakeWeight wakeWeight, Lsm6dsoSleepDur sleepDur)
+{
+  this->hi2c = hi2c;
+  this->i2cAddr = i2cAddr;
 	configure(odrAcc, fsAcc, odrGyr, fsGyr, wakeThs, wakeDur, wakeWeight, sleepDur);
 }
+
+HAL_StatusTypeDef Lsm6dso::readAcceleration(Acceleration *accel)
+{
+  lsm6dso_data_t data;
+  lsm6dso_md_t md;
+
+  // Leer datos del acelerómetro 
+  if (lsm6dso_data_get(&md, &data) != 0)
+    return HAL_ERROR;
+
+  // Copiar los mg convertidos
+  accel->ax = data.ui.xl.mg[0];
+  accel->ay = data.ui.xl.mg[1];
+  accel->az = data.ui.xl.mg[2];
+
+  return HAL_OK;
+}
+
+// TODO: CAMBIAR TODOS LOS NUMEROS MÁGICOS POR #DEFINE !!!
+
+/* Private methods ----------------------------------------------------------*/
 
 bool Lsm6dso::configure(Lsm6dsoI3C i3c, Lsm6dsoOdrAcc odrAcc, Lsm6dsoFsAcc fsAcc, Lsm6dsoOdrGyr odrGyr, Lsm6dsoFsGyr fsGyr,
 		Lsm6dsoWakeThs wakeThs, Lsm6dsoWakeDur wakeDur, Lsm6dsoWakeWeight wakeWeight, Lsm6dsoSleepDur sleepDur) {
@@ -41,11 +60,11 @@ uint8_t Lsm6dso::setConfigurationREG_CTRL3_C(Lsm6dsoIfInc ifInc){
 }
 
 uint8_t Lsm6dso::setConfigurationREG_CTRL6_C(Lsm6dsoXlHm xlHm){
-	return (static_cast<uint8_t>(XlHm) & LSM6DSO_XL_HM_MODE_MASK);
+	return (static_cast<uint8_t>(xlHm) & LSM6DSO_XL_HM_MODE_MASK);
 }
 
 uint8_t Lsm6dso::setConfigurationREG_CTRL7_G(Lsm6dsoGHm gHm){
-	return (static_cast<uint8_t>(GHm) & LSM6DSO_G_HM_MODE_MASK);
+	return (static_cast<uint8_t>(gHm) & LSM6DSO_G_HM_MODE_MASK);
 }
 
 uint8_t Lsm6dso::setConfigurationREG_CTRL9_XL(Lsm6dsoI3C i3c) {
@@ -53,12 +72,12 @@ uint8_t Lsm6dso::setConfigurationREG_CTRL9_XL(Lsm6dsoI3C i3c) {
 }
 
 uint8_t Lsm6dso::setConfigurationREG_TAP_CFG0(Lsm6dsoSlopeFilterEn sF){
-	return (static_cast<uint8_t>(SF) & LSM6DSO_SLOPE_FDS_MASK);
+	return (static_cast<uint8_t>(sF) & LSM6DSO_SLOPE_FDS_MASK);
 }
 
 uint8_t Lsm6dso::setConfigurationREG_TAP_CFG2(Lsm6dsoIntEn intEn, Lsm6dsoInactEn inActEn){
-	return (static_cast<uint8_t>(IntEn) & LSM6DSO_INT_EN_MASK) |
-		   (static_cast<uint8_t>(InActEn) & LSM6DSO_INACT_MASK);
+	return (static_cast<uint8_t>(intEn) & LSM6DSO_INT_EN_MASK) |
+		   (static_cast<uint8_t>(inActEn) & LSM6DSO_INACT_MASK);
 }
 
 uint8_t Lsm6dso::setConfigurationREG_WAKE_UP_THS(Lsm6dsoWakeThs wakeThs){
@@ -78,7 +97,7 @@ uint8_t Lsm6dso::setConfigurationREG_MD1_CFG(Lsm6dsoIntWU intWU){
 
 bool Lsm6dso::writeRegister(uint8_t reg, uint8_t value) {
 	uint8_t data = value;
-    return HAL_I2C_Mem_Write_DMA(&hi2c2, i2cAddr, reg, I2C_MEMADD_SIZE_8BIT, &data, 1) == HAL_OK;
+  return HAL_I2C_Mem_Write_DMA(this->hi2c2, this->i2cAddr, reg, I2C_MEMADD_SIZE_8BIT, &data, 1) == HAL_OK;
 }
 
 
@@ -122,6 +141,8 @@ float_t Lsm6dso::lsm6dso_from_lsb_to_nsec(int16_t lsb)
   return ((float_t)lsb * 25000.0f);
 }
 
+
+// ----- VERSIÓN CON CTX -----
 /**
   * @brief  Read generic device register
   *
@@ -132,6 +153,7 @@ float_t Lsm6dso::lsm6dso_from_lsb_to_nsec(int16_t lsb)
   * @retval          interface status (MANDATORY: return 0 -> no Error)
   *
   */
+/*
 int32_t Lsm6dso::lsm6dso_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data, uint16_t len){
   int32_t ret;
 
@@ -143,9 +165,16 @@ int32_t Lsm6dso::lsm6dso_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t 
   ret = ctx->read_reg(ctx->handle, reg, data, len);
 
   return ret;
+} */
+
+
+// ----- VERSIÓN CON HI2C2 -----
+int32_t Lsm6dso::lsm6dso_read_reg(uint8_t reg, uint8_t *data, uint16_t len){
+  return HAL_I2C_Mem_Read(this->hi2c2, this->i2cAddr, reg, I2C_MEMADD_SIZE_8BIT, data, len, 100);
 }
 
 
+// ----- VERSIÓN CON CTX -----
 /**
   * @brief  Linear acceleration output register.
   *         The value is expressed as a 16-bit word in two's complement.
@@ -155,6 +184,7 @@ int32_t Lsm6dso::lsm6dso_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t 
   * @retval             interface status (MANDATORY: return 0 -> no Error)
   *
   */
+/* 
 int32_t Lsm6dso::lsm6dso_acceleration_raw_get (const stmdev_ctx_t *ctx, int16_t *val){
 	uint8_t buff[6];
 	int32_t ret;
@@ -162,22 +192,38 @@ int32_t Lsm6dso::lsm6dso_acceleration_raw_get (const stmdev_ctx_t *ctx, int16_t 
 	// Leemos 6 bytes desde el registro base de aceleración (OUTX_L_A)
 	ret = lsm6dso_read_reg(ctx, REG_OUTX_L_A, buff, 6);
 
-	/*
-	val[0] = (int16_t)buff[1];
-	val[0] = (val[0] * 256) + (int16_t)buff[0];
-	val[1] = (int16_t)buff[3];
-	val[1] = (val[1] * 256) + (int16_t)buff[2];
-	val[2] = (int16_t)buff[5];
-	val[2] = (val[2] * 256) + (int16_t)buff[4];
-	*/
+	// val[0] = (int16_t)buff[1];
+	// val[0] = (val[0] * 256) + (int16_t)buff[0];
+	// val[1] = (int16_t)buff[3];
+	// val[1] = (val[1] * 256) + (int16_t)buff[2];
+	// val[2] = (int16_t)buff[5];
+	// val[2] = (val[2] * 256) + (int16_t)buff[4];
 
 	val[0] = (int16_t)((int16_t)buff[1] << LSM6DSO_WORD_SHIFT | buff[0]);  // X
 	val[1] = (int16_t)((int16_t)buff[3] << LSM6DSO_WORD_SHIFT | buff[2]);  // Y
 	val[2] = (int16_t)((int16_t)buff[5] << LSM6DSO_WORD_SHIFT | buff[4]);  // Z
 
 	return ret;
+}*/
+
+// ----- VERSIÓN CON HI2C2 -----
+int32_t Lsm6dso::lsm6dso_acceleration_raw_get(int16_t *val) {
+  uint8_t buff[6];
+  int32_t ret;
+
+  // Leemos 6 bytes desde el registro base de aceleración (OUTX_L_A)
+  ret = HAL_I2C_Mem_Read(this->hi2c, this->i2cAddr, REG_OUTX_L_A, I2C_MEMADD_SIZE_8BIT, buff, 6, HAL_MAX_DELAY);
+  if (ret != HAL_OK)
+    return -1;
+
+  val[0] = (int16_t)((int16_t)buff[1] << LSM6DSO_WORD_SHIFT | buff[0]);  // X
+  val[1] = (int16_t)((int16_t)buff[3] << LSM6DSO_WORD_SHIFT | buff[2]);  // Y
+  val[2] = (int16_t)((int16_t)buff[5] << LSM6DSO_WORD_SHIFT | buff[4]);  // Z
+
+  return 0;
 }
 
+// ----- VERSIÓN CON CTX -----
 /**
   * @brief  Read data in engineering unit.
   *
@@ -186,16 +232,17 @@ int32_t Lsm6dso::lsm6dso_acceleration_raw_get (const stmdev_ctx_t *ctx, int16_t 
   * @retval             interface status (MANDATORY: return 0 -> no Error)
   *
   */
+/*
 int32_t Lsm6dso::lsm6dso_data_get(const stmdev_ctx_t *ctx, const lsm6dso_md_t *md, lsm6dso_data_t *data) {
     uint8_t buff[14];
     int32_t ret = 0;
 
-    /* read data */
-     if (ctx != nullptr)
-     {
-       ret = lsm6dso_read_reg(ctx, REG_OUT_TEMP_L, buff, 14);
-       if (ret != 0) { return ret; }
-     }
+    // read data
+    if (ctx != nullptr)
+    {
+      ret = lsm6dso_read_reg(ctx, REG_OUT_TEMP_L, buff, 14);
+      if (ret != 0) return ret;
+    }
 
     uint8_t j = 0;
 
@@ -205,29 +252,73 @@ int32_t Lsm6dso::lsm6dso_data_get(const stmdev_ctx_t *ctx, const lsm6dso_md_t *m
     j += 2;
 
     // Acelerómetro
-    for (uint8_t i = 0; i < 3; ++i) {
-        data->ui.xl.raw[i] = (int16_t)((buff[j + 1] << LSM6DSO_WORD_SHIFT) | buff[j]);
-        j += 2;
+    ret = lsm6dso_acceleration_raw_get(ctx, data->ui.xl.raw);
+    if (ret != 0) return ret;
 
-        switch (md->ui.xl.fs) {
-            case LSM6DSO_XL_UI_2g:
-                data->ui.xl.mg[i] = lsm6dso_from_fs2_to_mg(data->ui.xl.raw[i]);
-                break;
-            case LSM6DSO_XL_UI_4g:
-                data->ui.xl.mg[i] = lsm6dso_from_fs4_to_mg(data->ui.xl.raw[i]);
-                break;
-            case LSM6DSO_XL_UI_8g:
-                data->ui.xl.mg[i] = lsm6dso_from_fs8_to_mg(data->ui.xl.raw[i]);
-                break;
-            case LSM6DSO_XL_UI_16g:
-                data->ui.xl.mg[i] = lsm6dso_from_fs16_to_mg(data->ui.xl.raw[i]);
-                break;
-            default:
-                data->ui.xl.mg[i] = 0.0f;
-                break;
-        }
+    for (uint8_t i = 0; i < 3; i++) {
+      switch (md->ui.xl.fs) {
+        case LSM6DSO_XL_UI_2g:
+          data->ui.xl.mg[i] = lsm6dso_from_fs2_to_mg(data->ui.xl.raw[i]);
+          break;
+        case LSM6DSO_XL_UI_4g:
+          data->ui.xl.mg[i] = lsm6dso_from_fs4_to_mg(data->ui.xl.raw[i]);
+          break;
+        case LSM6DSO_XL_UI_8g:
+          data->ui.xl.mg[i] = lsm6dso_from_fs8_to_mg(data->ui.xl.raw[i]);
+          break;
+        case LSM6DSO_XL_UI_16g:
+          data->ui.xl.mg[i] = lsm6dso_from_fs16_to_mg(data->ui.xl.raw[i]);
+          break;
+        default:
+          data->ui.xl.mg[i] = 0.0f;
+          break;
+      }
     }
 
     return 0;
+}
+*/
+
+// ----- VERSIÓN CON HI2C2 -----
+int32_t Lsm6dso::lsm6dso_data_get(const lsm6dso_md_t *md, lsm6dso_data_t *data) {
+  uint8_t buff[14];
+  int32_t ret = 0;
+
+  // Leer los 14 bytes desde OUT_TEMP_L (2 de temp + 6 de acc + 6 de gyro, si se desea)
+  ret = HAL_I2C_Mem_Read(this->hi2c, this->i2cAddr, REG_OUT_TEMP_L, I2C_MEMADD_SIZE_8BIT, buff, 14, HAL_MAX_DELAY);
+  if (ret != HAL_OK) return -1;
+
+  uint8_t j = 0;
+
+  // Temperatura
+  data->ui.heat.raw = (int16_t)((buff[j + 1] << LSM6DSO_WORD_SHIFT) | buff[j]);
+  data->ui.heat.deg_c = lsm6dso_from_lsb_to_celsius(data->ui.heat.raw);
+  j += 2;
+
+  // Acelerómetro
+  for (uint8_t i = 0; i < 3; i++) {
+    data->ui.xl.raw[i] = (int16_t)((buff[j + 1] << LSM6DSO_WORD_SHIFT) | buff[j]);
+    j += 2;
+
+    switch (md->ui.xl.fs) {
+      case LSM6DSO_XL_UI_2g:
+        data->ui.xl.mg[i] = lsm6dso_from_fs2_to_mg(data->ui.xl.raw[i]);
+        break;
+      case LSM6DSO_XL_UI_4g:
+        data->ui.xl.mg[i] = lsm6dso_from_fs4_to_mg(data->ui.xl.raw[i]);
+        break;
+      case LSM6DSO_XL_UI_8g:
+        data->ui.xl.mg[i] = lsm6dso_from_fs8_to_mg(data->ui.xl.raw[i]);
+        break;
+      case LSM6DSO_XL_UI_16g:
+        data->ui.xl.mg[i] = lsm6dso_from_fs16_to_mg(data->ui.xl.raw[i]);
+        break;
+      default:
+        data->ui.xl.mg[i] = 0.0f;
+        break;
+    }
+  }
+
+  return 0;
 }
 

--- a/Modules/IMU/lsm6dso.h
+++ b/Modules/IMU/lsm6dso.h
@@ -2,6 +2,8 @@
 #define MODULES_IMU_LSM6DSO_H_
 
 #include "lsm6dso_registers.h"
+#include "stm32wlxx_hal.h"
+#include "sensorDataType.h"
 
 // === Máscaras de campos de los registros ===
 #define LSM6DSO_ODR_XL_MASK     	(0b1111 	<< ODR_XL3)		    // CTRL1_XL (0x10)
@@ -227,20 +229,28 @@ enum class Lsm6dsoIntWU : uint8_t {
 
 // === OUTPUTS ===
 
+/* ¿Cuándo conviene eliminar ctx?
+Si sólo vas a usar I2C (y no SPI).
+Si siempre usás el mismo hi2cX (como hi2c2).
+Si no querés usar callbacks genéricos y preferís llamadas directas a HAL_I2C_Mem_Read y Write.
+*/
+
+/*
 typedef int32_t (*stmdev_write_ptr)(void *, uint8_t, const uint8_t *, uint16_t);
 typedef int32_t (*stmdev_read_ptr)(void *, uint8_t, uint8_t *, uint16_t);
 typedef void (*stmdev_mdelay_ptr)(uint32_t millisec);
 
 typedef struct
 {
-  /** Component mandatory fields **/
+  // Component mandatory fields 
   stmdev_write_ptr  write_reg;
   stmdev_read_ptr   read_reg;
-  /** Component optional fields **/
+  // Component optional fields 
   stmdev_mdelay_ptr   mdelay;
-  /** Customizable optional pointer **/
+  // Customizable optional pointer 
   void *handle;
 } stmdev_ctx_t;
+*/
 
 enum class Lsm6dsoOdrXlUi : uint8_t {
 	LSM6DSO_XL_UI_OFF         = 0x00, /* in power down */
@@ -443,8 +453,10 @@ typedef struct {
 
 class Lsm6dso {
 public:
-	Lsm6dso(uint8_t i2cAddr, Lsm6dsoI3C i3c, Lsm6dsoOdrAcc odrAcc, Lsm6dsoFsAcc fsAcc, Lsm6dsoOdrGyr odrGyr, Lsm6dsoFsGyr fsGyr, Lsm6dsoWakeThs wakeThs,
+	Lsm6dso(I2C_HandleTypeDef *hi2c, uint8_t i2cAddr, Lsm6dsoI3C i3c, Lsm6dsoOdrAcc odrAcc, Lsm6dsoFsAcc fsAcc, Lsm6dsoOdrGyr odrGyr, Lsm6dsoFsGyr fsGyr, Lsm6dsoWakeThs wakeThs,
 			    Lsm6dsoWakeDur wakeDur, Lsm6dsoWakeWeight wakeWeight, Lsm6dsoSleepDur sleepDur);
+
+	HAL_StatusTypeDef readAcceleration(Acceleration *accel);
 
 private:
 	bool configure(Lsm6dsoI3C i3c, Lsm6dsoOdrAcc odrAcc, Lsm6dsoFsAcc fsAcc, Lsm6dsoOdrGyr odrGyr, Lsm6dsoFsGyr fsGyr, Lsm6dsoWakeThs wakeThs,Lsm6dsoWakeDur wakeDur, Lsm6dsoWakeWeight wakeWeight, Lsm6dsoSleepDur sleepDur);
@@ -470,13 +482,15 @@ private:
   float_t lsm6dso_from_fs16_to_mg(int16_t lsb);
   float_t lsm6dso_from_lsb_to_celsius(int16_t lsb);
   float_t lsm6dso_from_lsb_to_nsec(int16_t lsb);
-  int32_t lsm6dso_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data, uint16_t len);
-  int32_t lsm6dso_acceleration_raw_get (const stmdev_ctx_t *ctx, int16_t *val);
-  int32_t lsm6dso_data_get(const stmdev_ctx_t *ctx, const lsm6dso_md_t *md, lsm6dso_data_t *data);
+  // int32_t lsm6dso_read_reg(const stmdev_ctx_t *ctx, uint8_t reg, uint8_t *data, uint16_t len);
+  int32_t lsm6dso_read_reg(uint8_t reg, uint8_t *data, uint16_t len);
+  // int32_t lsm6dso_acceleration_raw_get (const stmdev_ctx_t *ctx, int16_t *val);
+  int32_t lsm6dso_acceleration_raw_get(int16_t *val);
+  // int32_t lsm6dso_data_get(const stmdev_ctx_t *ctx, const lsm6dso_md_t *md, lsm6dso_data_t *data);
+  int32_t lsm6dso_data_get(const lsm6dso_md_t *md, lsm6dso_data_t *data);
 
-
-private:
   uint8_t i2cAddr;
+  I2C_HandleTypeDef *hi2c2;
 };
 
 


### PR DESCRIPTION
Modified IMU driver to add a simple readAcceleration to use in the sensorAcqTask()

Also modified some methods to delete ctx component and add only the hi2c2:

¿Cuándo conviene eliminar ctx?
Si sólo vas a usar I2C (y no SPI).
Si siempre usás el mismo hi2cX (como hi2c2).
Si no querés usar callbacks genéricos y preferís llamadas directas a HAL_I2C_Mem_Read y Write.